### PR TITLE
Use opqaue pointers for the internal device state structure

### DIFF
--- a/tools/lkl/include/lkl.h
+++ b/tools/lkl/include/lkl.h
@@ -207,7 +207,8 @@ struct lkl_dev_net_ops;
  * @returns a network device id (0 is valid) or a strictly negative value in
  * case of error
  */
-int lkl_netdev_add(struct lkl_netdev *nd, struct lkl_dev_net_ops *ops, void *mac);
+int lkl_netdev_add(struct lkl_netdev *nd, struct lkl_dev_net_ops *ops,
+		   void *mac);
 
 /**
  * lkl_netdev_get_ifindex - retrieve the interface index for a given network

--- a/tools/lkl/include/lkl.h
+++ b/tools/lkl/include/lkl.h
@@ -190,13 +190,9 @@ int lkl_set_ipv4_gateway(unsigned int addr);
 
 /**
  * lkl_netdev - host network device handle
- *
- * @fd - TAP device or packet socket file descriptor
  */
-union lkl_netdev {
-	int fd;
-	void *dpdk;
-};
+struct lkl_netdev;
+
 
 struct lkl_dev_net_ops;
 
@@ -211,7 +207,7 @@ struct lkl_dev_net_ops;
  * @returns a network device id (0 is valid) or a strictly negative value in
  * case of error
  */
-int lkl_netdev_add(union lkl_netdev nd, struct lkl_dev_net_ops *ops, void *mac);
+int lkl_netdev_add(struct lkl_netdev *nd, struct lkl_dev_net_ops *ops, void *mac);
 
 /**
  * lkl_netdev_get_ifindex - retrieve the interface index for a given network

--- a/tools/lkl/include/lkl_host.h
+++ b/tools/lkl/include/lkl_host.h
@@ -46,11 +46,11 @@ struct lkl_dev_blk_ops {
 extern struct lkl_dev_net_ops lkl_dev_net_ops;
 
 struct lkl_dev_net_ops {
-	int (*tx)(union lkl_netdev nd, void *data, int len);
-	int (*rx)(union lkl_netdev nd, void *data, int *len);
+	int (*tx)(struct lkl_netdev *nd, void *data, int len);
+	int (*rx)(struct lkl_netdev *nd, void *data, int *len);
 #define LKL_DEV_NET_POLL_RX		1
 #define LKL_DEV_NET_POLL_TX		2
-	int (*poll)(union lkl_netdev nd, int events);
+	int (*poll)(struct lkl_netdev *nd, int events);
 };
 
 #endif

--- a/tools/lkl/lib/hijack/init.c
+++ b/tools/lkl/lib/hijack/init.c
@@ -30,8 +30,8 @@
 
 #include "xlate.h"
 
-union lkl_netdev nuse_vif_tap_create(const char *ifname);
-union lkl_netdev nuse_vif_dpdk_create(const char *ifname);
+struct lkl_netdev *nuse_vif_tap_create(const char *ifname);
+struct lkl_netdev *nuse_vif_dpdk_create(const char *ifname);
 extern struct lkl_dev_net_ops tap_net_ops;
 extern struct lkl_dev_net_ops dpdk_net_ops;
 
@@ -45,7 +45,7 @@ hijack_init(void)
 	char *netmask_len = getenv("LKL_HIJACK_NET_NETMASK_LEN");
 	char *gateway = getenv("LKL_HIJACK_NET_GATEWAY");
 	char *debug = getenv("LKL_HIJACK_DEBUG");
-	union lkl_netdev nd;
+	struct lkl_netdev *nd;
 	struct lkl_dev_net_ops *ops = NULL;
 
 	if (vif && (strcmp(vif, "tap") == 0)) {

--- a/tools/lkl/lib/virtio-dpdk.c
+++ b/tools/lkl/lib/virtio-dpdk.c
@@ -66,22 +66,22 @@ static const struct rte_eth_txconf txconf = {
 static int portid;
 
 struct lkl_netdev_dpdk {
-    int portid;
-    struct rte_mempool *rxpool, *txpool;    /* rin buffer pool */
-    char txpoolname[16], rxpoolname[16];
-    /* burst receive context by rump dpdk code */
-    struct rte_mbuf *rms[MAX_PKT_BURST];
-    int npkts;
-    int bufidx;
+	int portid;
+	struct rte_mempool *rxpool, *txpool; /* rin buffer pool */
+	char txpoolname[16], rxpoolname[16];
+	/* burst receive context by rump dpdk code */
+	struct rte_mbuf *rms[MAX_PKT_BURST];
+	int npkts;
+	int bufidx;
 };
 
 static int net_tx(struct lkl_netdev *nd, void *data, int len)
 {
 	void *pkt;
 	struct rte_mbuf *rm;
-    struct lkl_netdev_dpdk *nd_dpdk;
+	struct lkl_netdev_dpdk *nd_dpdk;
 
-    nd_dpdk = (struct lkl_netdev_dpdk *)nd;
+	nd_dpdk = (struct lkl_netdev_dpdk *) nd;
 
 	rm = rte_pktmbuf_alloc(nd_dpdk->txpool);
 	pkt = rte_pktmbuf_append(rm, len);
@@ -93,9 +93,9 @@ static int net_tx(struct lkl_netdev *nd, void *data, int len)
 
 static int net_rx(struct lkl_netdev *nd, void *data, int *len)
 {
-    struct lkl_netdev_dpdk *nd_dpdk;
+	struct lkl_netdev_dpdk *nd_dpdk;
 
-    nd_dpdk = (struct lkl_netdev_dpdk *)nd;
+	nd_dpdk = (struct lkl_netdev_dpdk *) nd;
 
 	while (nd_dpdk->npkts > 0) {
 		struct rte_mbuf *rm, *rm0;
@@ -115,8 +115,8 @@ static int net_rx(struct lkl_netdev *nd, void *data, int *len)
 	}
 
 	if (nd_dpdk->npkts == 0) {
-		nd_dpdk->npkts = rte_eth_rx_burst(nd_dpdk->portid, 0, nd_dpdk->rms,
-					       MAX_PKT_BURST);
+		nd_dpdk->npkts = rte_eth_rx_burst(nd_dpdk->portid, 0,
+						  nd_dpdk->rms, MAX_PKT_BURST);
 		nd_dpdk->bufidx = 0;
 	}
 
@@ -147,7 +147,7 @@ struct lkl_netdev *nuse_vif_dpdk_create(const char *ifname)
 	static int dpdk_init = 0;
 	struct rte_eth_conf portconf;
 	struct rte_eth_link link;
-    struct lkl_netdev_dpdk *nd;
+	struct lkl_netdev_dpdk *nd;
 
 	if (!dpdk_init) {
 		ret = rte_eal_init(sizeof(ealargs) / sizeof(ealargs[0]),
@@ -164,7 +164,7 @@ struct lkl_netdev *nuse_vif_dpdk_create(const char *ifname)
 		dpdk_init = 1;
 	}
 
-    nd = malloc(sizeof(struct lkl_netdev_dpdk));
+	nd = malloc(sizeof(struct lkl_netdev_dpdk));
 	nd->portid = portid++;
 	snprintf(nd->txpoolname, 16, "%s%s", "tx", ifname);
 	snprintf(nd->rxpoolname, 16, "%s%s", "rx", ifname);
@@ -218,5 +218,5 @@ struct lkl_netdev *nuse_vif_dpdk_create(const char *ifname)
 	/* should be promisc ? */
 	rte_eth_promiscuous_enable(nd->portid);
 
-    return (struct lkl_netdev *)nd;
+	return (struct lkl_netdev *) nd;
 }

--- a/tools/lkl/lib/virtio-tap.c
+++ b/tools/lkl/lib/virtio-tap.c
@@ -18,16 +18,16 @@
 #include <lkl_host.h>
 
 struct lkl_netdev_tap {
-    int fd;
+	int fd;
 };
 
 
 static int net_tx(struct lkl_netdev *nd, void *data, int len)
 {
 	int ret;
-    struct lkl_netdev_tap *nd_tap;
+	struct lkl_netdev_tap *nd_tap;
 
-    nd_tap = (struct lkl_netdev_tap *)nd;
+	nd_tap = (struct lkl_netdev_tap *) nd;
 
 	ret = write(nd_tap->fd, data, len);
 	if (ret <= 0 && errno == -EAGAIN)
@@ -38,9 +38,9 @@ static int net_tx(struct lkl_netdev *nd, void *data, int len)
 static int net_rx(struct lkl_netdev *nd, void *data, int *len)
 {
 	int ret;
-    struct lkl_netdev_tap *nd_tap;
+	struct lkl_netdev_tap *nd_tap;
 
-    nd_tap = (struct lkl_netdev_tap *)nd;
+	nd_tap = (struct lkl_netdev_tap *) nd;
 
 	ret = read(nd_tap->fd, data, *len);
 	if (ret <= 0)
@@ -51,9 +51,9 @@ static int net_rx(struct lkl_netdev *nd, void *data, int *len)
 
 static int net_poll(struct lkl_netdev *nd, int events)
 {
-    struct lkl_netdev_tap *nd_tap;
+	struct lkl_netdev_tap *nd_tap;
 
-    nd_tap = (struct lkl_netdev_tap *)nd;
+	nd_tap = (struct lkl_netdev_tap *) nd;
 
 	struct pollfd pfd = {
 		.fd = nd_tap->fd,
@@ -92,9 +92,9 @@ struct lkl_netdev *nuse_vif_tap_create(const char *ifname)
 
 	nd = (struct lkl_netdev_tap *)malloc(sizeof(struct lkl_netdev_tap));
 	if (!nd) {
-        fprintf(stderr, "failed to allocate memory\n");
-        // TODO: propagate the error state, maybe use errno for that?
-        return 0;
+		fprintf(stderr, "failed to allocate memory\n");
+		/* TODO: propagate the error state, maybe use errno for that? */
+		return 0;
 	}
 
 	struct ifreq ifr = {

--- a/tools/lkl/lib/virtio_net.c
+++ b/tools/lkl/lib/virtio_net.c
@@ -13,7 +13,7 @@ struct virtio_net_dev {
 	struct virtio_dev dev;
 	struct lkl_virtio_net_config config;
 	struct lkl_dev_net_ops *ops;
-	union lkl_netdev nd;
+	struct lkl_netdev *nd;
 	struct virtio_net_poll rx_poll, tx_poll;
 };
 
@@ -81,7 +81,7 @@ void poll_thread(void *arg)
 	}
 }
 
-int lkl_netdev_add(union lkl_netdev nd, struct lkl_dev_net_ops *ops, void *mac)
+int lkl_netdev_add(struct lkl_netdev *nd, struct lkl_dev_net_ops *ops, void *mac)
 {
 	struct virtio_net_dev *dev;
 	static int count;

--- a/tools/lkl/lib/virtio_net.c
+++ b/tools/lkl/lib/virtio_net.c
@@ -81,7 +81,8 @@ void poll_thread(void *arg)
 	}
 }
 
-int lkl_netdev_add(struct lkl_netdev *nd, struct lkl_dev_net_ops *ops, void *mac)
+int lkl_netdev_add(struct lkl_netdev *nd, struct lkl_dev_net_ops *ops,
+		   void *mac)
 {
 	struct virtio_net_dev *dev;
 	static int count;

--- a/tools/lkl/tests/boot.c
+++ b/tools/lkl/tests/boot.c
@@ -337,7 +337,9 @@ out:
 }
 
 static int netdev_id = -1;
-union lkl_netdev netdev = { -1, };
+struct lkl_netdev_tap {
+    int fd;
+} netdev = { -1, };
 extern struct lkl_dev_net_ops tap_net_ops;
 
 #ifndef __MINGW32__
@@ -360,7 +362,7 @@ int test_netdev_add(char *str, int len)
 	if (ret < 0)
 		goto out;
 
-	ret = lkl_netdev_add(netdev, &tap_net_ops, NULL);
+	ret = lkl_netdev_add((struct lkl_netdev *)&netdev, &tap_net_ops, NULL);
 	if (ret < 0)
 		goto out;
 

--- a/tools/lkl/tests/boot.c
+++ b/tools/lkl/tests/boot.c
@@ -338,7 +338,7 @@ out:
 
 static int netdev_id = -1;
 struct lkl_netdev_tap {
-    int fd;
+	int fd;
 } netdev = { -1, };
 extern struct lkl_dev_net_ops tap_net_ops;
 


### PR DESCRIPTION
I think this makes the code easier to extend with even more backend drivers. The previously used common union caused implementation details to creep into `lkl.h` and I don't think backend implementations should change `lkl.h` at all. Additionally, strict users of the lkl library are now able to implement their own backends without modifying modifying and recompiling lkl.

Maybe it even makes sense to include the `lkl_dev_net_ops` part of `lkl_netdev` and use inheritance for implementation details but I'll leave that open for discussion.
